### PR TITLE
Added saving of recommendations as JSON files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *__pycache__*
 /env
 .vscode
+recommendations/**/*.json

--- a/scripts/adjacency_matrix.py
+++ b/scripts/adjacency_matrix.py
@@ -13,9 +13,13 @@ def gen_adjacency_matrices(sessions_data: pd.DataFrame, boolean_matrices=True) -
     
     views_data = sessions_data[sessions_data['event_type'].str.contains('VIEW_PRODUCT')]
     buy_data = sessions_data[sessions_data['event_type'].str.contains('BUY_PRODUCT')]
-    
+   
     view_adjacency_matrix = pd.crosstab(views_data['user_id'], views_data['product_id'])
     buy_adjacency_matrix = pd.crosstab(buy_data['user_id'], buy_data['product_id'])
+
+    for item in items_in_sessions:
+        if item not in buy_adjacency_matrix:
+            buy_adjacency_matrix.insert(len(buy_adjacency_matrix.columns), item, False)
 
     if boolean_matrices:
         view_adjacency_matrix = view_adjacency_matrix.astype(bool)

--- a/scripts/most_popular.py
+++ b/scripts/most_popular.py
@@ -1,11 +1,42 @@
 import sys
+import json
 import pandas as pd
 import numpy as np
 from adjacency_matrix import load_sessions_products, gen_adjacency_matrices
 
-def init() -> (dict, dict, pd.DataFrame):
+SAVE_PATH = 'recommendations/popularity/'
+
+def get_similar_categories(categories: list) -> dict:
+    parent_categories = {}
+    for category in categories:
+        parts = category.split(';')
+        parts.pop()
+        parent_categories[category] = parts
+    
+    similar_categories = {}
+    for category in categories:
+        similar_categories[category] = {}
+        for other_category in categories:
+            if category != other_category:
+                commonality = category_commonality(parent_categories[category], parent_categories[other_category])
+                if commonality in similar_categories[category]:
+                    similar_categories[category][commonality].append(other_category)
+                else:
+                    similar_categories[category][commonality] = [other_category]
+    
+    return similar_categories
+
+def category_commonality(a: list, b: list) -> int:
+    i = 0
+    j = 0
+    while i < len(a) and j < len(b) and a[i] == b[j]:
+        i = i + 1
+        j = j + 1
+    return i
+
+def init() -> (dict, dict, pd.DataFrame, pd.DataFrame):
     sessions_data, products_data = load_sessions_products()
-    views_data, _ = gen_adjacency_matrices(sessions_data)
+    views_data, purchases_data = gen_adjacency_matrices(sessions_data)
 
     sessions_data = sessions_data[sessions_data['event_type'].str.contains('VIEW_PRODUCT')]
     sessions_data = sessions_data.drop(['session_id', 'timestamp', 'event_type'], 'columns').drop_duplicates()
@@ -13,11 +44,23 @@ def init() -> (dict, dict, pd.DataFrame):
     category_popularity = sessions_data.join(products_data.set_index('product_id'), on='product_id').drop('price', 'columns')
     item_popularity = category_popularity
     category_popularity = pd.pivot_table(category_popularity, index='category_path', columns='user_id', aggfunc=np.count_nonzero)
+    similar_categories = get_similar_categories(category_popularity.index.to_list())
 
-    # Most popular categories for each user
-    most_popular_categories = {}
+    # Ordered categories for each user according to similarity to most popular category and popularity of itself
+    sorted_categories = {}
     for column in category_popularity.columns:
-        most_popular_categories[column[1]] = category_popularity[column].dropna().sort_values(ascending=False).to_frame('popularity').dropna()
+        categories_by_views = category_popularity[column].sort_values(ascending=False).to_frame('popularity')
+        most_popular_for_user = categories_by_views.iloc[0].name
+
+        similar_categories_for_user = similar_categories[most_popular_for_user]
+        ordered = categories_by_views.loc[most_popular_for_user].to_frame().transpose()
+
+        i = len(most_popular_for_user.split(';')) - 1
+        while i >= 0:
+            if i in similar_categories_for_user:
+                ordered = ordered.append(categories_by_views.loc[similar_categories_for_user[i]].sort_values('popularity', ascending=False))
+            i = i - 1
+        sorted_categories[column[1]] = ordered
 
     item_popularity = pd.pivot_table(item_popularity, index='product_id', columns='category_path', aggfunc=np.count_nonzero)
 
@@ -26,18 +69,39 @@ def init() -> (dict, dict, pd.DataFrame):
     for column in item_popularity.columns:
         most_popular_items[column[1]] = item_popularity[column].dropna().sort_values(ascending=False).to_frame('popularity')
 
-    return (most_popular_categories, most_popular_items, views_data)
+    return (sorted_categories, most_popular_items, views_data, purchases_data)
 
-def recommendations(categories: dict, items: dict, views: pd.DataFrame, uid: int, n: int = 10) -> list:
+def recommendations(categories: dict, items: dict, views: pd.DataFrame, purchases: pd.DataFrame, uid: int, n: int = 10) -> list:
     result = []
+    viewed = []
+    purchased = []
+
     for category, _ in categories[uid].iterrows():
         for item, _ in items[category].iterrows():
             if views.loc[uid, item] == False:
                 result.append(item)
                 if len(result) == n:
                     return result
+            elif purchases.loc[uid, item] == False:
+                viewed.append(item)
+            else: 
+                purchased.append(item)
+
+    result = result + viewed[:n - len(result)]
+    result = result + purchased[:n - len(result)]
     return result
 
+def save_to_files(recommendation_per_user: int = 10):
+    categories, items, views, purchases = init()
+    for uid in categories.keys():
+        data = {}
+        data['recommendations'] = recommendations(categories, items, views, purchases, uid, recommendation_per_user)
+        with open(SAVE_PATH + str(uid) + '.json', 'w') as outfile:
+            json.dump(data, outfile)
+
+
 if __name__ == "__main__":
-    categories, items, views = init()
-    print(recommendations(categories, items, views, int(sys.argv[1]), int(sys.argv[2])))
+    n = 10
+    if len(sys.argv) > 1:
+        n = sys.argv[1]
+    save_to_files(int(n))


### PR DESCRIPTION
Scripts `most_popular` and `collaborative_filtering` now take one argument each and save that many recommendations to JSON files. I have added these files to `.gitignore` to avoid filling the repo with useless data. Both models can now recommend previously seen and purchased items if amount of unseen items by a user is less than the requested recommendations amount. The item popularity model now also orders categories to be considered by similarity to the user's most popular category first, as opposed to ordering strictly by popularity.