### PR TITLE
Fixed division by 0 when calculating recall.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ A university project focused on engineering an ML solution to a problem. Chosen 
 The publicly shared project repo contains no usable data. Sample data, cleaned of most of recognizable information, is located in `data_raw/`.
 
 ## Contributors
- - [psawicki0](https://github.com/psawicki0)
+ - [p-sawicki](https://github.com/p-sawicki)
  - [Skwiwel](https://github.com/Skwiwel)
 
 ## Functionalities

--- a/scripts/model_test.py
+++ b/scripts/model_test.py
@@ -32,7 +32,7 @@ q: Queue, model: str, recommend: int, cf_params: list = []):
     # precision@k
     q.put(relevant / recommend)
     # recall@k
-    q.put(relevant / purchases.loc[user].sum())
+    q.put(relevant / max(1, purchases.loc[user].sum()))
 
 def test(model: str, recommend: int, session_data: pd.DataFrame, products_data: pd.DataFrame, cf_params: list = [], quiet: bool = False) -> (float, float):
     views, purchases = gen_adjacency_matrices(session_data)


### PR DESCRIPTION
Some users in the new data set have not made a single purchase, which broke the old recall calculation.

Results on new data (CF is with default parameters):
model | precision@10 | recall@10
--- | --- | ---
rand | 0.03 | 0.04
mp | 0.22 | 0.28
cf | 0.63 | 0.86